### PR TITLE
Fix title ellipsizing

### DIFF
--- a/src/twitch/TwitchArchive.js
+++ b/src/twitch/TwitchArchive.js
@@ -92,7 +92,7 @@ module.exports = class TwitchArchive extends EventEmitter {
             .replace(/{twitchCategory}/g, '(unavailable due to Twitch not providing data)');
 
         if (title.length > 100) {
-            title = `${video.title.substr(0, title.length - 100 - ' - [ STREAM ARCHIVE ]'.length - 6)}... - [ STREAM ARCHIVE ]`;
+            title = `${video.title.substr(0, 100 - ' - [ STREAM ARCHIVE ]'.length - 3)}... - [ STREAM ARCHIVE ]`;
             description += `\nOriginal title: ${video.title}`;
         }
 


### PR DESCRIPTION
Titles over 100 characters had 27 additional characters removed, leading to titles of simply "... - [ STREAM ARCHIVE ]" instead of the cut off title. This fixes the final title at 100 characters exactly.